### PR TITLE
docs: add info that the web agent is not actively maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This Actor is a work in progress. Got feedback? Head to the [Issues tab](https://console.apify.com/actors/dLXH5Ia8gLsNjieKV/issues) in Console.
+> ⚠️ The AI Web Agent is an experimental project and is currently not actively maintained. While we have plans for long-term improvements, these will not be implemented in the near future. We welcome and appreciate any contributions, including pull requests or documentation enhancements.
 > 
 
 


### PR DESCRIPTION
Based on slack [discussion](https://apify.slack.com/archives/C01GVMUSRUN/p1716435614935319) add information that the web agent is not actively maintained.

FYI @jirimoravcik 